### PR TITLE
Update call info

### DIFF
--- a/calls/README.md
+++ b/calls/README.md
@@ -1,34 +1,9 @@
 # Community Calls
 
-## 2020-02-13 Stacks Governance Call #1 - Introduction
-
-Blockstack Governance - Community Call 2020/02/13
-- [Presentation Slides](20200213_community_call_001.pdf)
-- [Video Recording](https://youtu.be/GilQ9qU4Sa0)
-
-## 2020-03-02 Stacks Governance Call #2
-
-Blockstack Governance - Community Call 2020/03/02
-- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/3)
-- [Video Recording](https://youtu.be/jAEHyq4TKeI)
-- [Brief summary](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)
-
-## 2020-03-11 Stacks Governance Call #3
-
-Blockstack Governance - Community Call 2020/03/11
-- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/5)
-- [Video Recording](https://youtu.be/d7cGndifjR0)
-- [Unedited Call Notes](https://github.com/stacksgov/resources/issues/12)
-- [List of questions about the Foundation](https://github.com/stacksgov/pm/issues/11)
-
-## 2020-03-18 Stacks Governance Call #4
-
-Blockstack Governance - Community Call 2020/03/18
-- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/9)
-- [Video Recording](https://youtu.be/u8lZsVFCFtc)
-- [Unedited Call Notes](https://github.com/stacksgov/resources/issues/19)
-
-## 2020-03-25 Stacks Governance Call #5 - Upcoming
-
-Blockstack Governance - Community Call 2020/03/25
-- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/16)
+| No   | Date       | Agenda  | Video | Notes | Docs |
+| ---- | ---------- | ------- | ----- | ----- | ---- |
+| 0005 | 2020-03-25  | [Agenda](https://github.com/stacksgov/pm/issues/16)  | TBD  | TBD  | TBD  |
+| 0004 | 2020-03-18 | [Agenda](https://github.com/stacksgov/pm/issues/9)  | [Video](https://youtu.be/u8lZsVFCFtc)  | [Notes](https://github.com/stacksgov/resources/issues/19)  | @dantrevino Presentation Slides / @blocks8 Foundation Notes |
+| 0003 | 2020-03-11 | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |
+| 0002 | 2020-03-02 | [Agenda](https://github.com/stacksgov/pm/issues/3) | [Video](https://youtu.be/jAEHyq4TKeI)  | [Notes](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)  | n/a |
+| 0001 | 2020-02-13 | n/a | [Video](https://youtu.be/GilQ9qU4Sa0) | [TBD](https://github.com/stacksgov/resources/issues/16) | [Presentation Slides](20200213_community_call_001.pdf) |

--- a/calls/README.md
+++ b/calls/README.md
@@ -19,3 +19,10 @@ Blockstack Governance - Community Call 2020/03/11
 - [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/5)
 - [Video Recording](https://youtu.be/d7cGndifjR0)
 - [Unedited Call Notes](https://github.com/stacksgov/resources/issues/12)
+
+## 2020-03-18 Stacks Governance Call #4
+
+Blockstack Governance - Community Call 2020/03/18
+- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/9)
+- [Video Recording](https://youtu.be/u8lZsVFCFtc)
+- [Unedited Call Notes](https://github.com/stacksgov/resources/issues/19)

--- a/calls/README.md
+++ b/calls/README.md
@@ -20,6 +20,7 @@ Below is a list of all prior/completed calls, including links to their agenda, r
 
 | No   | Date       | Time | Agenda  | Video | Notes | Docs |
 | ---- | ---------- | ---- | ------- | ----- | ----- | ---- |
+| 0006 | 2020-04-01 | 1400 UTC | TBD | TBD | TBD | TBD |
 | 0005 | 2020-03-25 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/16)  | [Video](https://youtu.be/gpw6byKPeIw)  | TBD  | n/a  |
 | 0004 | 2020-03-18 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/9)  | [Video](https://youtu.be/u8lZsVFCFtc)  | [Notes](https://github.com/stacksgov/resources/issues/19)  | @dantrevino Presentation Slides / @blocks8 Foundation Notes |
 | 0003 | 2020-03-11 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |

--- a/calls/README.md
+++ b/calls/README.md
@@ -26,3 +26,8 @@ Blockstack Governance - Community Call 2020/03/18
 - [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/9)
 - [Video Recording](https://youtu.be/u8lZsVFCFtc)
 - [Unedited Call Notes](https://github.com/stacksgov/resources/issues/19)
+
+## 2020-03-25 Stacks Governance Call #5 - Upcoming
+
+Blockstack Governance - Community Call 2020/03/25
+- [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/16)

--- a/calls/README.md
+++ b/calls/README.md
@@ -19,6 +19,7 @@ Blockstack Governance - Community Call 2020/03/11
 - [Agenda &amp; Discussion Items](https://github.com/stacksgov/pm/issues/5)
 - [Video Recording](https://youtu.be/d7cGndifjR0)
 - [Unedited Call Notes](https://github.com/stacksgov/resources/issues/12)
+- [List of questions about the Foundation](https://github.com/stacksgov/pm/issues/11)
 
 ## 2020-03-18 Stacks Governance Call #4
 

--- a/calls/README.md
+++ b/calls/README.md
@@ -20,7 +20,7 @@ Below is a list of all prior/completed calls, including links to their agenda, r
 
 | No   | Date       | Time | Agenda  | Video | Notes | Docs |
 | ---- | ---------- | ---- | ------- | ----- | ----- | ---- |
-| 0005 | 2020-03-25 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/16)  | TBD  | TBD  | TBD  |
+| 0005 | 2020-03-25 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/16)  | [Video](https://youtu.be/gpw6byKPeIw)  | TBD  | n/a  |
 | 0004 | 2020-03-18 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/9)  | [Video](https://youtu.be/u8lZsVFCFtc)  | [Notes](https://github.com/stacksgov/resources/issues/19)  | @dantrevino Presentation Slides / @blocks8 Foundation Notes |
 | 0003 | 2020-03-11 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |
 | 0002 | 2020-03-02 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/3) | [Video](https://youtu.be/jAEHyq4TKeI)  | [Notes](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)  | n/a |

--- a/calls/README.md
+++ b/calls/README.md
@@ -1,9 +1,9 @@
 # Community Calls
 
-| No   | Date       | Agenda  | Video | Notes | Docs |
-| ---- | ---------- | ------- | ----- | ----- | ---- |
-| 0005 | 2020-03-25  | [Agenda](https://github.com/stacksgov/pm/issues/16)  | TBD  | TBD  | TBD  |
-| 0004 | 2020-03-18 | [Agenda](https://github.com/stacksgov/pm/issues/9)  | [Video](https://youtu.be/u8lZsVFCFtc)  | [Notes](https://github.com/stacksgov/resources/issues/19)  | @dantrevino Presentation Slides / @blocks8 Foundation Notes |
-| 0003 | 2020-03-11 | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |
-| 0002 | 2020-03-02 | [Agenda](https://github.com/stacksgov/pm/issues/3) | [Video](https://youtu.be/jAEHyq4TKeI)  | [Notes](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)  | n/a |
-| 0001 | 2020-02-13 | n/a | [Video](https://youtu.be/GilQ9qU4Sa0) | [TBD](https://github.com/stacksgov/resources/issues/16) | [Presentation Slides](20200213_community_call_001.pdf) |
+| No   | Date       | Time | Agenda  | Video | Notes | Docs |
+| ---- | ---------- | ---- | ------- | ----- | ----- | ---- |
+| 0005 | 2020-03-25 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/16)  | TBD  | TBD  | TBD  |
+| 0004 | 2020-03-18 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/9)  | [Video](https://youtu.be/u8lZsVFCFtc)  | [Notes](https://github.com/stacksgov/resources/issues/19)  | @dantrevino Presentation Slides / @blocks8 Foundation Notes |
+| 0003 | 2020-03-11 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |
+| 0002 | 2020-03-02 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/3) | [Video](https://youtu.be/jAEHyq4TKeI)  | [Notes](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)  | n/a |
+| 0001 | 2020-02-13 | 1500 UTC | n/a | [Video](https://youtu.be/GilQ9qU4Sa0) | [TBD](https://github.com/stacksgov/resources/issues/16) | [Presentation Slides](20200213_community_call_001.pdf) |

--- a/calls/README.md
+++ b/calls/README.md
@@ -1,5 +1,23 @@
 # Community Calls
 
+## Purpose
+
+The governance working group will be hosting regular community calls to update the community about the progress of the project, and to give everyone a chance to have their voice heard. An initial, introductory call was held on February 13, and future calls will be held every Wednesday at 7am PT/10am ET/2pm UTC/5pm CEST/10pm CST (please reach out on Discord if you'd like to be added to the recurring email invitation).
+
+## Who can Attend
+
+Stacks governance is a community-run initiative! As such, it cannot work without your help, and without the input of as many community members as possible. _You do not need anyone’s permission to get involved and contribute to the initiative._ The #governance working group channel on [Blockstack Discord](https://discordapp.com/invite/ny6wGkx) is a great place to begin getting involved, as many community members regularly share ideas, updates, and resources there. You can also find a number of topics under the [governance category](https://forum.blockstack.org/c/governance) on the Blockstack Community Forum which need your input.
+
+## Agenda Items
+
+You can find a link to the proposed agenda for the next call in the table below. The agenda for each meeting is saved as [an issue on Github](https://github.com/stacksgov/pm/issues) under the stacksgov [project management repository](https://github.com/stacksgov/pm).
+
+Please feel free to propose additions/amendments!
+
+## Previous Meetings
+
+Below is a list of all prior/completed calls, including links to their agenda, recording, and additional content.
+
 | No   | Date       | Time | Agenda  | Video | Notes | Docs |
 | ---- | ---------- | ---- | ------- | ----- | ----- | ---- |
 | 0005 | 2020-03-25 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/16)  | TBD  | TBD  | TBD  |
@@ -7,3 +25,11 @@
 | 0003 | 2020-03-11 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/5) | [Video](https://youtu.be/d7cGndifjR0)  | [Notes](https://github.com/stacksgov/resources/issues/12)  | [Foundation Questions](https://github.com/stacksgov/pm/issues/11)  |
 | 0002 | 2020-03-02 | 1400 UTC | [Agenda](https://github.com/stacksgov/pm/issues/3) | [Video](https://youtu.be/jAEHyq4TKeI)  | [Notes](https://github.com/stacksgov/pm/issues/3#issuecomment-593482885)  | n/a |
 | 0001 | 2020-02-13 | 1500 UTC | n/a | [Video](https://youtu.be/GilQ9qU4Sa0) | [TBD](https://github.com/stacksgov/resources/issues/16) | [Presentation Slides](20200213_community_call_001.pdf) |
+
+## General Resources
+
+See [Stacks Governance Resources](https://github.com/stacksgov/resources/blob/master/README.md) for additional information related to governance of the Stacks blockchain.
+
+## Licensing
+
+This repository and all contributions herein are licensed under [Creative Commons Zero v1.0 Universal](https://github.com/stacksgov/resources/blob/master/LICENSE). Please note that, by contributing to this repository, whether via commit, pull request, issue, comment, or in any other fashion, **you are explicitly agreeing that all of your contributions will fall under the same permissive license.**


### PR DESCRIPTION
Added info and links for [completed call 4](https://github.com/stacksgov/pm/issues/9) and [upcoming call 5](https://github.com/stacksgov/pm/issues/16).