### PR TITLE
Remove survey repo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [Governance Calls](calls/README.md) for resources related to governance call
 
 ### Governance Survey
 
-We are conducting a governance survey, inspired by a similar survey conducted in the Ethereum community last year. Learn more about the survey, the goals of the survey, and how to contribute in [this forum thread](https://forum.blockstack.org/t/community-governance-survey/10387) or in [this Github issue.](https://github.com/stacksgov/pm/issues/1)
+We are conducting a governance survey, inspired by a similar survey conducted in the Ethereum community last year. Learn more about the survey, the goals of the survey, and how to contribute in [this forum thread](https://forum.blockstack.org/t/community-governance-survey/10387) or in [this Github issue](https://github.com/stacksgov/pm/issues/1).
 
 ### Interview Notes
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ See [Interview Notes](interviews/) for notes from one on one interviews with sta
 
 - [updates](https://github.com/stacksgov/updates): updates regularly to share the latest progress of the governance project with the community
 - [resources](https://github.com/stacksgov/resources): this page of links, resources, and info on working group calls
-- [survey](https://github.com/stacksgov/survey):  we’re planning to conduct a governance survey, inspired by a similar survey conducted in the Ethereum community last year. Learn more about the survey, the goals of the survey, and how to contribute, in [this forum thread](https://forum.blockstack.org/t/community-governance-survey/10387)
 - [pm](https://github.com/stacksgov/pm/projects/1): project management board related to all areas above
 
 ### Blockstack Community Forum

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ From [Stacks Governance Update #1 - 4 March, 2020](https://github.com/stacksgov/
 
 See [Governance Calls](calls/README.md) for resources related to governance calls.
 
-### Interview notes
+### Governance Survey
+
+We are conducting a governance survey, inspired by a similar survey conducted in the Ethereum community last year. Learn more about the survey, the goals of the survey, and how to contribute in [this forum thread](https://forum.blockstack.org/t/community-governance-survey/10387) or in [this Github issue.](https://github.com/stacksgov/pm/issues/1)
+
+### Interview Notes
 
 See [Interview Notes](interviews/) for notes from one on one interviews with stakeholders about governance.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See [Interview Notes](interviews/) for notes from one on one interviews with sta
 - [updates](https://github.com/stacksgov/updates): updates regularly to share the latest progress of the governance project with the community
 - [resources](https://github.com/stacksgov/resources): this page of links, resources, and info on working group calls
 - [pm](https://github.com/stacksgov/pm/projects/1): project management board related to all areas above
+- [proposals](https://github.com/stacksgov/proposals): stores miscellaneous governance proposals, and we are still determining the role of this repository and these proposals relative to the [existing SIP process](https://github.com/blockstack/stacks-blockchain/blob/master/sip/sip-000-stacks-improvement-proposal-process.md)
 
 ### Blockstack Community Forum
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Resources related to governance of the Stacks blockchain.
 - [Stacks Governance](#stacks-governance)
   - [Get Involved!](#get-involved)
   - [Governance Calls](#governance-calls)
+  - [Governance Survey](#governance-survey)
   - [Interview Notes](#interview-notes)
   - [Github Repositories](#github-repositories)
   - [Blockstack Community Forum](#blockstack-community-forum)


### PR DESCRIPTION
This PR will remove the reference to the survey repository so we can delete the repo, creates a separate section for describing the survey, and updates the repo list [per the new sop.](https://github.com/stacksgov/pm/blob/master/sop.md)

The thought behind this was that the survey information lives both [in the forum](https://forum.blockstack.org/t/community-governance-survey/10387) and [in an issue](https://github.com/stacksgov/pm/issues/1), and does not need its own dedicated repo.

If we need a place to share results or any other info regarding the survey, it can be done in a `/survey` folder under the resources repository.