### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-resources.stacks.org


### PR DESCRIPTION
After talking to @blocks8 we are going to stick with the github domain for now, removing the file will fix the redirect until a later date.